### PR TITLE
ci: split prod (tag) and staging (stg branch) release workflows

### DIFF
--- a/.github/workflows/release-staging.yml
+++ b/.github/workflows/release-staging.yml
@@ -1,16 +1,16 @@
-name: Release
+name: Release (staging)
 
 on:
   push:
-    tags: ['v*']
+    branches: [stg]
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   release:
     runs-on: ubuntu-latest
-    environment: production
+    environment: staging
     env:
       AWS_REGION: ${{ secrets.AWS_REGION }}
       RELEASE_BUCKET: ${{ secrets.RELEASE_BUCKET }}
@@ -28,16 +28,19 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.AWS_REGION }}
+      # Snapshot mode: no tag required. Artifacts are suffixed with
+      # the short commit SHA (e.g. surf_linux_amd64_SNAPSHOT-abc1234).
       - uses: goreleaser/goreleaser-action@v6
         with:
-          args: release --clean
+          args: release --clean --snapshot
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Update latest version pointer
+      - name: Update staging latest pointer
         env:
           RELEASE_LATEST_URL: ${{ secrets.RELEASE_LATEST_URL }}
           CLOUDFRONT_DISTRIBUTION_ID: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}
           CLOUDFRONT_LATEST_PATH: ${{ secrets.CLOUDFRONT_LATEST_PATH }}
         run: |
-          echo -n "${{ github.ref_name }}" | aws s3 cp - "${RELEASE_LATEST_URL}" --content-type "text/plain" --cache-control "max-age=60"
+          SHORT_SHA="${GITHUB_SHA:0:7}"
+          echo -n "stg-${SHORT_SHA}" | aws s3 cp - "${RELEASE_LATEST_URL}" --content-type "text/plain" --cache-control "max-age=60"
           aws cloudfront create-invalidation --distribution-id "${CLOUDFRONT_DISTRIBUTION_ID}" --paths "${CLOUDFRONT_LATEST_PATH}"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -45,3 +45,6 @@ blobs:
 
 release:
   disable: true
+
+snapshot:
+  version_template: "stg-{{ .ShortCommit }}"

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1
 	github.com/tent/http-link-go v0.0.0-20130702225549-ac974c61c2f9
+	github.com/zalando/go-keyring v0.2.8
 	golang.org/x/exp v0.0.0-20230321023759-10a507213a29
 	golang.org/x/term v0.30.0
 	golang.org/x/text v0.35.0
@@ -80,7 +81,6 @@ require (
 	github.com/x448/float16 v0.8.4 // indirect
 	github.com/yuin/goldmark v1.5.3 // indirect
 	github.com/yuin/goldmark-emoji v1.0.1 // indirect
-	github.com/zalando/go-keyring v0.2.8 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/image v0.38.0 // indirect
 	golang.org/x/net v0.38.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -166,6 +166,8 @@ github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3A
 github.com/spf13/viper v1.21.0 h1:x5S+0EU27Lbphp4UKm1C+1oQO+rKx36vfCoaVebLFSU=
 github.com/spf13/viper v1.21.0/go.mod h1:P0lhsswPGWD/1lZJ9ny3fYnVqxiegrlNrEmgLjbTCAY=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
+github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=


### PR DESCRIPTION
## Summary

- \`release.yml\` (prod): tag \`v*\` push → \`environment: production\`. Version comes from git tag.
- \`release-staging.yml\` (new): push to \`stg\` branch → \`environment: staging\`. Uses \`goreleaser --snapshot\` so no tag needed.
- \`.goreleaser.yaml\`: add \`snapshot.version_template: \"stg-{ShortCommit}\"\` — stg builds get versions like \`stg-abc1234\`. Prod mode ignores this block entirely (verified locally).
- \`go mod tidy\` cleanup from goreleaser's before-hook.

## Test plan

- [x] Locally verified \`goreleaser release --snapshot --clean\` produces \`surf version stg-<sha>\` with no tag required.
- [x] Locally verified \`goreleaser release --clean\` (prod mode) with a git tag \`v9.9.9-test\` produces \`surf version 9.9.9-test\` — snapshot block is ignored.
- [ ] Configure \`staging\` environment secrets (stg bucket, CloudFront, IAM) before merging.
- [ ] Configure \`production\` environment secrets before first real release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)