### PR TITLE
fix(stg): publish snapshot blobs and key them by .Version

### DIFF
--- a/.github/workflows/release-staging.yml
+++ b/.github/workflows/release-staging.yml
@@ -28,11 +28,12 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.AWS_REGION }}
-      # Snapshot mode: no tag required. Artifacts are suffixed with
-      # the short commit SHA (e.g. surf_linux_amd64_SNAPSHOT-abc1234).
+      # Snapshot mode: no tag required. Without explicit --skip, snapshot
+      # also skips publish (which is what uploads to S3), so binaries never
+      # leave the runner. Skip only announce + validate so blobs upload.
       - uses: goreleaser/goreleaser-action@v6
         with:
-          args: release --clean --snapshot
+          args: release --clean --snapshot --skip=announce,validate
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload install.sh to staging

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -41,7 +41,10 @@ blobs:
   - provider: s3
     bucket: "{{ .Env.RELEASE_BUCKET }}"
     region: "{{ .Env.AWS_REGION }}"
-    directory: "{{ .Env.RELEASE_DIRECTORY }}/{{.Tag}}"
+    # Snapshot builds have no real tag (.Tag defaults to v0.0.0), so key on
+    # .Version instead (which is "stg-<sha>" in snapshot mode, matches the
+    # latest pointer). Tag releases still use .Tag for human-readable paths.
+    directory: "{{ .Env.RELEASE_DIRECTORY }}/{{ if .IsSnapshot }}{{ .Version }}{{ else }}{{ .Tag }}{{ end }}"
 
 release:
   disable: true


### PR DESCRIPTION
## Problem

Previous staging release runs completed "successfully" but no binaries landed on the CDN — only `install.sh` and the `latest` pointer showed up (those use direct `aws s3 cp` after goreleaser). Probing any versioned path (`/cli/releases/stg-<sha>/surf_darwin_arm64`, `/v0.0.0/...`) returned 403.

Two independent bugs:

### 1. `--snapshot` skips publish by default

Goreleaser log shows:
```
• skipping announce, publish, and validate...
```

S3 blob upload runs during the publish phase, so snapshot builds never left the runner.

**Fix**: `--skip=announce,validate` (omit `publish`).

### 2. Snapshot path doesn't match latest pointer

In snapshot mode with no prior tags, `.Tag` falls back to `v0.0.0`. Our blobs directory was `{{.Tag}}` → `cli/releases/v0.0.0/`, but the latest pointer is `stg-<sha>` — off by one path component.

**Fix**: conditional on `.IsSnapshot` — use `.Version` for snapshot (which is `stg-<sha>` per `snapshot.version_template`), `.Tag` for real tag releases.

## Test plan

- [ ] Merge, then fast-forward stg onto main, push stg
- [ ] Wait ~2min, then: `curl -I https://downloads-stg.asksurf.ai/cli/releases/$(curl -s https://downloads-stg.asksurf.ai/cli/releases/latest)/surf_darwin_arm64` should return 200
- [ ] Confirm prod behavior unchanged (tag push still uses `v*` paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)