### PR TITLE
fix(stg): use ephemeral tag, drop --snapshot mode

### DIFF
--- a/.github/workflows/release-staging.yml
+++ b/.github/workflows/release-staging.yml
@@ -28,12 +28,16 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.AWS_REGION }}
-      # Snapshot mode: no tag required. Without explicit --skip, snapshot
-      # also skips publish (which is what uploads to S3), so binaries never
-      # leave the runner. Skip only announce + validate so blobs upload.
+      # Create an ephemeral tag just for this run so goreleaser takes the
+      # normal (non-snapshot) path and actually publishes blobs to S3. The
+      # tag lives only in the runner's checkout — permissions above are
+      # contents: read so it can never be pushed. When the runner VM is
+      # destroyed, the tag is gone.
+      - name: Create ephemeral tag
+        run: git tag "stg-${GITHUB_SHA:0:7}"
       - uses: goreleaser/goreleaser-action@v6
         with:
-          args: release --clean --snapshot --skip=announce,validate
+          args: release --clean --skip=announce
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload install.sh to staging

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -41,13 +41,7 @@ blobs:
   - provider: s3
     bucket: "{{ .Env.RELEASE_BUCKET }}"
     region: "{{ .Env.AWS_REGION }}"
-    # Snapshot builds have no real tag (.Tag defaults to v0.0.0), so key on
-    # .Version instead (which is "stg-<sha>" in snapshot mode, matches the
-    # latest pointer). Tag releases still use .Tag for human-readable paths.
-    directory: "{{ .Env.RELEASE_DIRECTORY }}/{{ if .IsSnapshot }}{{ .Version }}{{ else }}{{ .Tag }}{{ end }}"
+    directory: "{{ .Env.RELEASE_DIRECTORY }}/{{ .Tag }}"
 
 release:
   disable: true
-
-snapshot:
-  version_template: "stg-{{ .ShortCommit }}"


### PR DESCRIPTION
## Why

Goreleaser's `--snapshot` mode forcibly skips the publish phase regardless of `--skip` args. That's where S3 blob upload happens, so staging binaries never left the runner (confirmed in Actions log: "skipping announce, publish, and validate").

## How

Bypass snapshot mode entirely by creating an ephemeral git tag in the CI runner before goreleaser runs. Goreleaser then takes the normal path, publishes blobs to S3, and keys them by `{{.Tag}}` (= `stg-<sha>`).

The tag:

- Exists only in the runner's checkout
- Cannot be pushed — workflow has `permissions: contents: read`
- Dies with the VM when the job ends

Also removes `snapshot:` block and `{{ if .IsSnapshot }}` conditional from `.goreleaser.yaml` since we don't use snapshot mode anymore.

## Test plan

- [ ] Merge, ff stg, push stg
- [ ] `curl -I https://downloads-stg.asksurf.ai/cli/releases/$(curl -s .../latest)/surf_darwin_arm64` → 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)