### PR TITLE
feat(cli): add docs link to root --help footer (review #19)

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -266,7 +266,10 @@ func Init(name string, version string) {
 	)
 	Root.SetHelpTemplate(`{{with (or .Long .Short)}}{{. | trimTrailingWhitespaces | highlight}}
 
-{{end}}{{if or .Runnable .HasSubCommands}}{{.UsageString}}{{end}}`)
+{{end}}{{if or .Runnable .HasSubCommands}}{{.UsageString}}{{end}}{{if not .HasParent}}
+Documentation: https://docs.asksurf.ai/llms.txt
+Report issues: https://github.com/asksurf-ai/surf-cli/issues
+{{end}}`)
 
 	head := &cobra.Command{
 		GroupID:           "generic",

--- a/cmd/surf/usage_test.go
+++ b/cmd/surf/usage_test.go
@@ -200,6 +200,31 @@ func TestUnknownCommandSuggestsTypoFix(t *testing.T) {
 	}
 }
 
+// TestHelpFooterDocLink verifies that root --help includes the docs link
+// and issues URL, and that subcommand --help does NOT (avoids clutter).
+func TestHelpFooterDocLink(t *testing.T) {
+	bin := buildSurfBin(t)
+
+	t.Run("root help has footer", func(t *testing.T) {
+		out, _ := exec.Command(bin, "--help").CombinedOutput()
+		s := string(out)
+		if !strings.Contains(s, "https://docs.asksurf.ai/llms.txt") {
+			t.Errorf("root --help missing docs link:\n%s", s)
+		}
+		if !strings.Contains(s, "https://github.com/asksurf-ai/surf-cli/issues") {
+			t.Errorf("root --help missing issues link:\n%s", s)
+		}
+	})
+
+	t.Run("subcommand help has no footer", func(t *testing.T) {
+		out, _ := exec.Command(bin, "market-price", "--help").CombinedOutput()
+		s := string(out)
+		if strings.Contains(s, "https://docs.asksurf.ai/llms.txt") {
+			t.Errorf("market-price --help should NOT carry root footer:\n%s", s)
+		}
+	})
+}
+
 // TestVersionFlag verifies that -v and --version both print the version string.
 func TestVersionFlag(t *testing.T) {
 	bin := buildSurfBin(t)


### PR DESCRIPTION
## Summary

Adds two lines to the bottom of \`surf --help\`:

\`\`\`
Documentation: https://docs.asksurf.ai/llms.txt
Report issues: https://github.com/asksurf-ai/surf-cli/issues
\`\`\`

Scoped to root via \`{{ if not .HasParent }}\` so subcommand help stays clean.

Ref: \`docs/CLI_V1_ALPHA_26_REVIEW.md\` item #19

## Workflow

Same branch was merged to \`stg\` (PR #11). Verified on stg binary:
- \`surf --help\` shows footer ✓
- \`surf market-price --help\`, \`surf catalog --help\` etc. no footer ✓

Now promoting to \`main\` so the next prod tag ships this.

## Test plan

- [x] \`TestHelpFooterDocLink\` passes
- [ ] Verified end-to-end on stg CDN binary (\`v0.0.0-stg.71e97c6\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)