### PR TITLE
feat(cli): mark required flags as "(required)" in --help

### DIFF
--- a/cli/param.go
+++ b/cli/param.go
@@ -109,38 +109,46 @@ func (p Param) OptionName() string {
 func (p Param) AddFlag(flags *pflag.FlagSet) any {
 	name := p.OptionName()
 	def := p.Default
+	desc := p.Description
+	if p.Required {
+		if desc != "" {
+			desc += " (required)"
+		} else {
+			desc = "(required)"
+		}
+	}
 
 	switch p.Type {
 	case "boolean":
 		if def == nil {
 			def = false
 		}
-		return flags.Bool(name, def.(bool), p.Description)
+		return flags.Bool(name, def.(bool), desc)
 	case "integer":
 		if def == nil {
 			def = 0
 		}
-		return flags.Int(name, typeConvert(def, 0).(int), p.Description)
+		return flags.Int(name, typeConvert(def, 0).(int), desc)
 	case "number":
 		if def == nil {
 			def = 0.0
 		}
-		return flags.Float64(name, typeConvert(def, float64(0.0)).(float64), p.Description)
+		return flags.Float64(name, typeConvert(def, float64(0.0)).(float64), desc)
 	case "string":
 		if def == nil {
 			def = ""
 		}
-		return flags.String(name, def.(string), p.Description)
+		return flags.String(name, def.(string), desc)
 	case "array[boolean]":
 		if def == nil {
 			def = []bool{}
 		}
-		return flags.BoolSlice(name, def.([]bool), p.Description)
+		return flags.BoolSlice(name, def.([]bool), desc)
 	case "array[integer]":
 		if def == nil {
 			def = []int{}
 		}
-		return flags.IntSlice(name, def.([]int), p.Description)
+		return flags.IntSlice(name, def.([]int), desc)
 	case "array[number]":
 		log.Printf("number slice not implemented for param %s", p.Name)
 		return nil
@@ -159,7 +167,7 @@ func (p Param) AddFlag(flags *pflag.FlagSet) any {
 			}
 			def = tmp
 		}
-		return flags.StringSlice(name, def.([]string), p.Description)
+		return flags.StringSlice(name, def.([]string), desc)
 	}
 
 	return nil

--- a/cli/param_test.go
+++ b/cli/param_test.go
@@ -67,3 +67,33 @@ func TestParamFlag(t *testing.T) {
 		})
 	}
 }
+
+func TestParamFlagRequiredSuffix(t *testing.T) {
+	tests := []struct {
+		name        string
+		required    bool
+		description string
+		wantUsage   string
+	}{
+		{"optional with description", false, "Some description", "Some description"},
+		{"optional without description", false, "", ""},
+		{"required with description", true, "Some description", "Some description (required)"},
+		{"required without description", true, "", "(required)"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := Param{
+				Name:        "test",
+				Type:        "string",
+				Description: tt.description,
+				Required:    tt.required,
+			}
+			flags := pflag.NewFlagSet("", pflag.PanicOnError)
+			p.AddFlag(flags)
+
+			flag := flags.Lookup("test")
+			assert.NotNil(t, flag)
+			assert.Equal(t, tt.wantUsage, flag.Usage)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Auto-generated flags from the OpenAPI spec were formatted identically whether required or optional, so users (and agents) reading `--help` couldn't tell which to pass.
- `Param.Required` was already populated and enforced at runtime (`cli/operation.go`) — this just threads it into the description shown in `--help`.

### Before

```
Flags:
  -h, --help                 help for polymarket-markets
      --limit int            Results per page (min 1, max 100) (default 20)
      --market-slug string   Market slug identifier
      --offset int           Pagination offset (min 0)
```

### After

```
Flags:
  -h, --help                 help for polymarket-markets
      --limit int            Results per page (min 1, max 100) (default 20)
      --market-slug string   Market slug identifier (required)
      --offset int           Pagination offset (min 0)
```

## Why not `cobra.MarkFlagRequired`

Cobra's built-in sets an annotation that's consumed by shell completion and runtime enforcement, but the default usage template **doesn't render anything in `--help`** — it wouldn't actually fix the visible-to-humans (and agents) problem. It would also double-fire with the existing `missing required flag(s): ...` error in `cli/operation.go`, replacing its helpful `See: surf <cmd> --help` hint with Cobra's plainer default.

Minimal description-suffix approach keeps the current error path intact.

## Test plan

- [x] `go test ./...` passes
- [x] `surf polymarket-markets --help` shows `(required)` on `--market-slug`
- [x] `surf fund-ranking --help` shows `(required)` on `--metric`
- [x] Optional flags unchanged (no `(required)` suffix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)