### PR TITLE
fix(ci): skip unix permission-bit assertion in TestCopyBinary on windows

### DIFF
--- a/cmd/surf/install_test.go
+++ b/cmd/surf/install_test.go
@@ -40,9 +40,11 @@ func TestCopyBinary(t *testing.T) {
 	if string(got) != "binary-content" {
 		t.Errorf("copied content = %q, want %q", got, "binary-content")
 	}
-	info, _ := os.Stat(dst)
-	if info.Mode().Perm()&0111 == 0 {
-		t.Error("copied file is not executable")
+	if runtime.GOOS != "windows" {
+		info, _ := os.Stat(dst)
+		if info.Mode().Perm()&0111 == 0 {
+			t.Error("copied file is not executable")
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

`TestCopyBinary` has been failing on every recent `main` run because the final assertion checks a Unix concept that doesn't exist on Windows:

```go
info, _ := os.Stat(dst)
if info.Mode().Perm()&0111 == 0 {
    t.Error("copied file is not executable")
}
```

Windows has no POSIX permission bits — it determines executability from the file extension (`.exe`, `.bat`, etc.). `info.Mode().Perm()&0111` always returns 0 on Windows regardless of what `copyFile` does, so the test can never pass there.

This gates **just that assertion** (not the whole test) on `runtime.GOOS != "windows"`, so Windows CI still verifies the content-copy path — it just skips the Unix-only permission check.

## Why not `t.Skip()` the whole test?

`TestCreateSymlink` right below it does `t.Skip()` because symlink semantics differ. `TestCopyBinary` has two assertions: content equality (cross-platform) and executable bit (Unix-only). Skipping only the one that doesn't apply preserves Windows coverage of `copyFile`'s primary job.

## Test plan

- [x] `go test ./cmd/surf/ -run TestCopyBinary -v` passes on darwin
- [ ] CI Windows job turns green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)