### PR TITLE
feat(cli): mark required flags as "(required)" in --help (promote to main)

### DIFF
--- a/cli/param.go
+++ b/cli/param.go
@@ -109,38 +109,46 @@ func (p Param) OptionName() string {
 func (p Param) AddFlag(flags *pflag.FlagSet) any {
 	name := p.OptionName()
 	def := p.Default
+	desc := p.Description
+	if p.Required {
+		if desc != "" {
+			desc += " (required)"
+		} else {
+			desc = "(required)"
+		}
+	}
 
 	switch p.Type {
 	case "boolean":
 		if def == nil {
 			def = false
 		}
-		return flags.Bool(name, def.(bool), p.Description)
+		return flags.Bool(name, def.(bool), desc)
 	case "integer":
 		if def == nil {
 			def = 0
 		}
-		return flags.Int(name, typeConvert(def, 0).(int), p.Description)
+		return flags.Int(name, typeConvert(def, 0).(int), desc)
 	case "number":
 		if def == nil {
 			def = 0.0
 		}
-		return flags.Float64(name, typeConvert(def, float64(0.0)).(float64), p.Description)
+		return flags.Float64(name, typeConvert(def, float64(0.0)).(float64), desc)
 	case "string":
 		if def == nil {
 			def = ""
 		}
-		return flags.String(name, def.(string), p.Description)
+		return flags.String(name, def.(string), desc)
 	case "array[boolean]":
 		if def == nil {
 			def = []bool{}
 		}
-		return flags.BoolSlice(name, def.([]bool), p.Description)
+		return flags.BoolSlice(name, def.([]bool), desc)
 	case "array[integer]":
 		if def == nil {
 			def = []int{}
 		}
-		return flags.IntSlice(name, def.([]int), p.Description)
+		return flags.IntSlice(name, def.([]int), desc)
 	case "array[number]":
 		log.Printf("number slice not implemented for param %s", p.Name)
 		return nil
@@ -159,7 +167,7 @@ func (p Param) AddFlag(flags *pflag.FlagSet) any {
 			}
 			def = tmp
 		}
-		return flags.StringSlice(name, def.([]string), p.Description)
+		return flags.StringSlice(name, def.([]string), desc)
 	}
 
 	return nil

--- a/cli/param_test.go
+++ b/cli/param_test.go
@@ -67,3 +67,33 @@ func TestParamFlag(t *testing.T) {
 		})
 	}
 }
+
+func TestParamFlagRequiredSuffix(t *testing.T) {
+	tests := []struct {
+		name        string
+		required    bool
+		description string
+		wantUsage   string
+	}{
+		{"optional with description", false, "Some description", "Some description"},
+		{"optional without description", false, "", ""},
+		{"required with description", true, "Some description", "Some description (required)"},
+		{"required without description", true, "", "(required)"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := Param{
+				Name:        "test",
+				Type:        "string",
+				Description: tt.description,
+				Required:    tt.required,
+			}
+			flags := pflag.NewFlagSet("", pflag.PanicOnError)
+			p.AddFlag(flags)
+
+			flag := flags.Lookup("test")
+			assert.NotNil(t, flag)
+			assert.Equal(t, tt.wantUsage, flag.Usage)
+		})
+	}
+}


### PR DESCRIPTION
Promotes PR #15 (already merged into `stg` and verified in staging) to `main`.

## Summary

- Appends ` (required)` to the description of required flags auto-generated from the OpenAPI spec, so `--help` visually distinguishes required from optional.
- Verified live on staging (v0.0.0-stg.b06adc6): 62 required flags across 94 commands all now show the suffix.

## Interaction with existing spec-side `REQUIRED.` prefixes

A staging audit found that a handful of flag descriptions in the OpenAPI spec were manually prefixed with `REQUIRED.` — but coverage is very low (3 out of 62 required flags, ~5%):

- `polymarket-events --event-slug`
- `polymarket-markets --market-slug`
- `social-mindshare --q`

For those three, both the prefix and the auto-suffix will show (e.g. `REQUIRED. Polymarket market slug ... (required)`). The other 59 required flags rely entirely on this PR to get labeled.

Follow-up: open an issue against the backend to clean up those 3 manual prefixes so the OpenAPI spec's `required: true` field is the single source of truth.

## Test plan

- [x] `go test ./...` passes
- [x] Verified on staging: `surf polymarket-markets --help`, `surf fund-ranking --help`, and 60 other commands show `(required)` on required flags
- [x] Optional flags unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)