### PR TITLE
feat(cli): auto-sync API spec on cache miss

### DIFF
--- a/cmd/surf/main.go
+++ b/cmd/surf/main.go
@@ -190,6 +190,20 @@ func main() {
 		}
 	}
 
+	// Lazy-sync: fresh install (or expired cache) + user is invoking an API
+	// command → fetch the spec once so commands register and the call can
+	// proceed, instead of failing with "unknown command" or "no cached API
+	// spec — run surf sync first".
+	if cli.LoadCachedAPI("surf") == nil && needsCachedAPI() {
+		fmt.Fprintln(os.Stderr, "No cached API spec, syncing...")
+		viper.Set("rsh-no-cache", true)
+		if _, err := cli.Load("https://api.asksurf.ai/gateway", cli.Root); err != nil {
+			fmt.Fprintf(os.Stderr, "Auto-sync failed: %v\n", err)
+			// Fall through — the downstream "no cached API spec" /
+			// "unknown command" path will produce a more specific error.
+		}
+	}
+
 	// Populate "Available API Commands" from cached API spec as full
 	// operation commands (with flags, Long description, etc.). These are
 	// used when --help/-h skips injection, and also for Root help display.
@@ -228,6 +242,27 @@ func main() {
 
 	cli.ReportCLIEvent(cli.GetCurrentCommand(), exitCode, errMsg)
 	os.Exit(exitCode)
+}
+
+// needsCachedAPI reports whether the current argv invokes a command that
+// requires the cached OpenAPI spec. Meta commands (auth, sync, help, version,
+// install, completion, telemetry, feedback, catalog) work without it.
+// list-operations DOES need it — it enumerates the spec — so it's not in
+// the meta set and will trigger auto-sync on cache miss.
+func needsCachedAPI() bool {
+	meta := map[string]bool{
+		"auth": true, "sync": true, "catalog": true,
+		"help": true, "completion": true, "version": true, "install": true,
+		"telemetry": true, "feedback": true,
+	}
+	for _, arg := range os.Args[1:] {
+		if strings.HasPrefix(arg, "-") {
+			continue
+		}
+		return !meta[arg]
+	}
+	// No command given → will show root help, no sync needed.
+	return false
 }
 
 // shouldInjectAPIName returns true if os.Args represents an API operation

--- a/cmd/surf/main_test.go
+++ b/cmd/surf/main_test.go
@@ -62,3 +62,36 @@ func TestShouldInjectAPIName(t *testing.T) {
 		})
 	}
 }
+
+func TestNeedsCachedAPI(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{"no command", []string{"surf"}, false},
+		{"auth is meta", []string{"surf", "auth"}, false},
+		{"sync is meta", []string{"surf", "sync"}, false},
+		{"version is meta", []string{"surf", "version"}, false},
+		{"install is meta", []string{"surf", "install"}, false},
+		{"help is meta", []string{"surf", "help"}, false},
+		{"catalog is meta", []string{"surf", "catalog", "show", "ethereum_dex_trades"}, false},
+		{"telemetry is meta", []string{"surf", "telemetry"}, false},
+		{"feedback is meta", []string{"surf", "feedback", "test"}, false},
+		{"API command needs cache", []string{"surf", "polymarket-markets"}, true},
+		{"list-operations needs cache", []string{"surf", "list-operations"}, true},
+		{"API command with --help needs cache", []string{"surf", "polymarket-markets", "--help"}, true},
+		{"leading flags skipped when finding command", []string{"surf", "--debug", "polymarket-markets"}, true},
+		{"leading flags skipped before meta command", []string{"surf", "--debug", "auth"}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			oldArgs := os.Args
+			defer func() { os.Args = oldArgs }()
+			os.Args = tt.args
+			if got := needsCachedAPI(); got != tt.want {
+				t.Errorf("needsCachedAPI() with args=%v = %v, want %v", tt.args, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Staging mirror of #18 (replaces closed #19 after stg branch was reset).

## Summary

Without a cached OpenAPI spec, every API command fails — either with \`unknown command: polymarket-markets\` (API commands aren't registered at startup) or \`no cached API spec — run surf sync first\` (list-operations). Agents hit this ~17 times in recent eval runs when they skipped the initial \`surf sync\` step that SKILL.md asks for.

This makes the sync happen automatically on cache miss, so the \`surf sync\` step becomes a CLI-level invariant instead of something agents have to remember.

## Staging test plan

- [ ] After staging release, run: \`rm ~/.surf/surf.cbor && surf list-operations\` → expect auto-sync + operations list
- [ ] Run: \`surf polymarket-markets --help\` on fresh cache → expect auto-sync + full help
- [ ] Run: \`surf auth\`, \`surf version\`, \`surf install\` on fresh cache → should NOT trigger auto-sync
- [ ] Verify stderr message \`"No cached API spec, syncing..."\` appears only on the first call

See #18 for full details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)