### PR TITLE
docs: fix install path (~/.surf/bin → ~/.local/bin)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Every API endpoint is available as a CLI command, dynamically generated from the
 curl -fsSL https://downloads.asksurf.ai/cli/releases/install.sh | sh
 ```
 
-Installs to `~/.surf/bin`. No sudo required.
+Installs to `~/.local/bin`. No sudo required.
 
 To install a specific version:
 
@@ -80,12 +80,12 @@ Configuration is stored in `~/.surf/`.
 
 ### Local development
 
-Build the binary and symlink it into `~/.surf/bin/surf` so the `surf` in your
+Build the binary and symlink it into `~/.local/bin/surf` so the `surf` in your
 PATH resolves to your local build:
 
 ```sh
 go build -o bin/surf ./cmd/surf
-ln -sf "$(pwd)/bin/surf" ~/.surf/bin/surf
+ln -sf "$(pwd)/bin/surf" ~/.local/bin/surf
 
 surf version   # confirm you're on the local build
 surf help


### PR DESCRIPTION
## Summary

The README claimed the installer puts the binary in \`~/.surf/bin\`, but the actual install path is \`~/.local/bin\` (see \`installDir()\` + \`install_test.go:11-19\`). Fix three references:

- L13 (Install section): \"Installs to \`~/.surf/bin\`\" → \`~/.local/bin\`
- L83, L88 (Local development, added in #14): symlink target \`~/.surf/bin/surf\` → \`~/.local/bin/surf\`

Anyone following the old Local development instructions would create a broken symlink in a directory that doesn't exist by default — the original \`~/.local/bin/surf\` from the installer would continue to take precedence in PATH, silently defeating the whole \"test your local build\" workflow.

## Test plan

- [x] \`install.sh\` points to \`~/.local/bin\` (verified)
- [x] On a clean machine, the \`ln -sf\` command now writes into a directory the installer already populated, so \`surf version\` resolves to the local build as intended

🤖 Generated with [Claude Code](https://claude.com/claude-code)