### PR TITLE
feat(cli): render enum values as type placeholder in --help

### DIFF
--- a/cli/param.go
+++ b/cli/param.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"reflect"
+	"strings"
 
 	"github.com/iancoleman/strcase"
 	"github.com/spf13/pflag"
@@ -26,16 +27,30 @@ func typeConvert(from, to any) any {
 
 // Param represents an API operation input parameter.
 type Param struct {
-	Type        string `json:"type" yaml:"type"`
-	Name        string `json:"name" yaml:"name"`
-	DisplayName string `json:"display_name,omitempty" yaml:"display_name,omitempty"`
-	Description string `json:"description,omitempty" yaml:"description,omitempty"`
-	Style       Style  `json:"style,omitempty" yaml:"style,omitempty"`
-	Explode     bool   `json:"explode,omitempty" yaml:"explide,omitempty"`
-	Required    bool   `json:"required,omitempty" yaml:"required,omitempty"`
-	Default     any    `json:"default,omitempty" yaml:"default,omitempty"`
-	Example     any    `json:"example,omitempty" yaml:"example,omitempty"`
+	Type        string   `json:"type" yaml:"type"`
+	Name        string   `json:"name" yaml:"name"`
+	DisplayName string   `json:"display_name,omitempty" yaml:"display_name,omitempty"`
+	Description string   `json:"description,omitempty" yaml:"description,omitempty"`
+	Style       Style    `json:"style,omitempty" yaml:"style,omitempty"`
+	Explode     bool     `json:"explode,omitempty" yaml:"explide,omitempty"`
+	Required    bool     `json:"required,omitempty" yaml:"required,omitempty"`
+	Default     any      `json:"default,omitempty" yaml:"default,omitempty"`
+	Example     any      `json:"example,omitempty" yaml:"example,omitempty"`
+	Enum        []string `json:"enum,omitempty" yaml:"enum,omitempty"`
 }
+
+// enumStringValue is a pflag.Value whose Type() reports a custom placeholder
+// like "{a|b|c}". pflag's UnquoteUsage falls back to Value.Type() when the
+// usage string has no back-quoted word, so this lets us render enum choices
+// directly in the flag's type column.
+type enumStringValue struct {
+	val     *string
+	typeStr string
+}
+
+func (e *enumStringValue) String() string     { return *e.val }
+func (e *enumStringValue) Set(s string) error { *e.val = s; return nil }
+func (e *enumStringValue) Type() string       { return e.typeStr }
 
 // Parse the parameter from a string input (e.g. command line argument)
 func (p Param) Parse(value string) (any, error) {
@@ -137,6 +152,16 @@ func (p Param) AddFlag(flags *pflag.FlagSet) any {
 	case "string":
 		if def == nil {
 			def = ""
+		}
+		if len(p.Enum) > 0 {
+			placeholder := "{" + strings.Join(p.Enum, "|") + "}"
+			// Skip the custom placeholder if it would be too wide and break
+			// alignment in --help output. pflag falls back to "string".
+			if len(placeholder) <= 40 {
+				v := def.(string)
+				flags.Var(&enumStringValue{val: &v, typeStr: placeholder}, name, desc)
+				return &v
+			}
 		}
 		return flags.String(name, def.(string), desc)
 	case "array[boolean]":

--- a/cli/param_test.go
+++ b/cli/param_test.go
@@ -68,6 +68,36 @@ func TestParamFlag(t *testing.T) {
 	}
 }
 
+func TestParamFlagEnumPlaceholder(t *testing.T) {
+	tests := []struct {
+		name     string
+		enum     []string
+		wantType string
+	}{
+		{"no enum", nil, "string"},
+		{"two values", []string{"tier", "portfolio_count"}, "{tier|portfolio_count}"},
+		{"three values", []string{"asc", "desc", "none"}, "{asc|desc|none}"},
+		{"too wide falls back to string", []string{
+			"one_really_long_value", "another_really_long_value",
+		}, "string"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := Param{
+				Name: "test",
+				Type: "string",
+				Enum: tt.enum,
+			}
+			flags := pflag.NewFlagSet("", pflag.PanicOnError)
+			p.AddFlag(flags)
+
+			flag := flags.Lookup("test")
+			assert.NotNil(t, flag)
+			assert.Equal(t, tt.wantType, flag.Value.Type())
+		})
+	}
+}
+
 func TestParamFlagRequiredSuffix(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/openapi/openapi.go
+++ b/openapi/openapi.go
@@ -339,10 +339,21 @@ func openapiOperation(cmd *cobra.Command, method string, uriTemplate *url.URL, p
 
 		displayName := getExtOr(p.Extensions, ExtName, "")
 		description := getExtOr(p.Extensions, ExtDescription, p.Description)
+		// Strip Markdown backticks so pflag's UnquoteUsage doesn't pull the
+		// first back-quoted word out of the description as the flag's type
+		// placeholder (e.g. --metric `tier` → "--metric tier" column).
+		description = strings.ReplaceAll(description, "`", "")
 
-		// Append enum values and min/max constraints to the flag
-		// description so they appear in --help output.
+		var enums []string
 		if schema != nil {
+			if len(schema.Enum) > 0 {
+				enums = make([]string, 0, len(schema.Enum))
+				for _, e := range schema.Enum {
+					enums = append(enums, e.Value)
+				}
+			}
+			// Append enum values and min/max constraints to the flag
+			// description so they appear in --help output.
 			description = appendSchemaHints(description, schema)
 		}
 
@@ -355,6 +366,7 @@ func openapiOperation(cmd *cobra.Command, method string, uriTemplate *url.URL, p
 			Required:    p.Required != nil && *p.Required,
 			Default:     def,
 			Example:     example,
+			Enum:        enums,
 		}
 
 		if p.Explode != nil {


### PR DESCRIPTION
## Summary

- For string params with an OpenAPI enum, `--help` used to show the first back-quoted word from the description (e.g. `--metric tier`) as the type placeholder. Agents read this as "default = tier" and skipped the required flag.
- Root cause: spec descriptions legitimately use Markdown backticks to emphasize enum values, but pflag's `UnquoteUsage` (flag.go:594) pulls the first back-quoted word out as the flag's type placeholder. Two conventions collide on the same character.
- Fix: strip backticks from descriptions in `openapi.go`, then register a custom pflag `Value` whose `Type()` returns `{a|b|c}` so the placeholder column shows the full choice list. Falls back to plain `string` when the placeholder would exceed 40 chars and break column alignment.

### Before
```
--metric tier   Ranking metric. Can be tier (lower is better) or `portfolio_count` (number of invested projects). (required)
```

### After
```
--metric {tier|portfolio_count}   Ranking metric. Can be tier (lower is better) or portfolio_count (number of invested projects). (required)
```

Other commands now show clearer enum columns:
- `--interval {5m|1h|1d|7d}` (social-mindshare)
- `--order {asc|desc}` (market-ranking)
- `--sort-by {market_cap|change_24h|volume_24h}` (market-ranking)
- `--metric {volume|fee|fees|revenue|tvl|users}` (project-defi-metrics)

Refs `docs/issues.md` #3.

## Test plan

- [x] `go test ./...` passes (incl. new `TestParamFlagEnumPlaceholder` covering no-enum / 2-value / 3-value / too-wide-fallback cases)
- [x] Local verification: `surf sync` → `surf fund-ranking --help` shows `{tier|portfolio_count}` column
- [ ] Staging: after this PR is merged to `stg` and the staging release publishes, run `surf install` (staging channel) and re-verify:
  - [ ] `surf fund-ranking --help` → `--metric {tier|portfolio_count}`
  - [ ] `surf social-mindshare --help` → `--interval {5m|1h|1d|7d}`
  - [ ] `surf market-ranking --help` → `--order {asc|desc}` and `--sort-by {market_cap|change_24h|volume_24h}`
  - [ ] Regression check: a non-enum string flag (e.g. `--q string`, `--chain string`) still shows `string`
  - [ ] Regression check: `(required)` and `(default …)` suffixes still render

🤖 Generated with [Claude Code](https://claude.com/claude-code)