### PR TITLE
fix(cli): replace broken root help example

### DIFF
--- a/cmd/surf/main.go
+++ b/cmd/surf/main.go
@@ -50,7 +50,7 @@ func main() {
 
 	// Inject "surf" as the API name into os.Args so restish's Run() loads
 	// the API config. Skip injection for commands that don't need API loading.
-	//   surf market-futures --symbol BTC  →  [surf, surf, market-futures, --symbol, BTC]
+	//   surf market-price --symbol BTC  →  [surf, surf, market-price, --symbol, BTC]
 	//   surf auth                         →  [surf, auth]  (no injection)
 	if shouldInjectAPIName() {
 		os.Args = append([]string{os.Args[0], "surf"}, os.Args[1:]...)
@@ -71,7 +71,7 @@ func main() {
 	cli.Root.SuggestionsMinimumDistance = 2
 	cli.Root.Short = "Surf data platform CLI"
 	cli.Root.Long = "Query the Surf data platform — crypto market data, on-chain analytics, and more."
-	cli.Root.Example = "  surf market-futures --symbol BTC\n  surf search-project --q bitcoin"
+	cli.Root.Example = "  surf market-price --symbol BTC\n  surf search-project --q bitcoin"
 	// Override restish's default root behavior (acts as GET handler with MinimumNArgs(1)).
 	cli.Root.Args = nil
 	cli.Root.Run = func(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
## Summary
- `surf help` advertised `surf market-futures --symbol BTC`, which fails with `unknown flag: --symbol`. `market-futures` is now a ranking-style snapshot endpoint and explicitly does not accept `--symbol`.
- Replace with `surf market-price --symbol BTC` — the canonical symbol-keyed time-series query, returns real price history end-to-end.
- Fix the matching example in the inline comment above the API-name injection.

## Test plan
- [x] `go build ./cmd/surf`
- [x] `surf market-price --symbol BTC` returns price points
- [x] `surf search-project --q bitcoin` (other example, untouched) still works
- [ ] After merge: install stg release, verify `surf help` Examples block shows the new line

🤖 Generated with [Claude Code](https://claude.com/claude-code)