### PR TITLE
docs(cli): point --help footer to agents.asksurf.ai

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -267,7 +267,7 @@ func Init(name string, version string) {
 	Root.SetHelpTemplate(`{{with (or .Long .Short)}}{{. | trimTrailingWhitespaces | highlight}}
 
 {{end}}{{if or .Runnable .HasSubCommands}}{{.UsageString}}{{end}}{{if not .HasParent}}
-Documentation: https://docs.asksurf.ai/llms.txt
+Documentation: https://agents.asksurf.ai/llms.txt
 Report issues: https://github.com/asksurf-ai/surf-cli/issues
 {{end}}`)
 

--- a/cmd/surf/usage_test.go
+++ b/cmd/surf/usage_test.go
@@ -208,7 +208,7 @@ func TestHelpFooterDocLink(t *testing.T) {
 	t.Run("root help has footer", func(t *testing.T) {
 		out, _ := exec.Command(bin, "--help").CombinedOutput()
 		s := string(out)
-		if !strings.Contains(s, "https://docs.asksurf.ai/llms.txt") {
+		if !strings.Contains(s, "https://agents.asksurf.ai/llms.txt") {
 			t.Errorf("root --help missing docs link:\n%s", s)
 		}
 		if !strings.Contains(s, "https://github.com/asksurf-ai/surf-cli/issues") {
@@ -219,7 +219,7 @@ func TestHelpFooterDocLink(t *testing.T) {
 	t.Run("subcommand help has no footer", func(t *testing.T) {
 		out, _ := exec.Command(bin, "market-price", "--help").CombinedOutput()
 		s := string(out)
-		if strings.Contains(s, "https://docs.asksurf.ai/llms.txt") {
+		if strings.Contains(s, "https://agents.asksurf.ai/llms.txt") {
 			t.Errorf("market-price --help should NOT carry root footer:\n%s", s)
 		}
 	})


### PR DESCRIPTION
## Summary

\`docs.asksurf.ai\` is a stale Mintlify mirror; the canonical Surf docs now live at \`agents.asksurf.ai/docs\` (served by the surf-landing Next.js app). Update the root \`--help\` footer URL and the test that pins it.

- \`cli/cli.go\` — \`https://docs.asksurf.ai/llms.txt\` → \`https://agents.asksurf.ai/llms.txt\` (verified 200)
- \`cmd/surf/usage_test.go\` — same string in the assertion

## Test plan
- [x] \`go test ./cmd/surf/ -run TestHelpFooterDocLink\` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)