### PR TITLE
feat(cli): optionally mirror parsed responses to a sink directory

### DIFF
--- a/cli/request.go
+++ b/cli/request.go
@@ -574,6 +574,11 @@ func MakeRequestAndFormat(req *http.Request) {
 			// GetExitCode to return 4, matching the §4.1 contract.
 			synthetic := newTransportErrorResponse(code, msg)
 			lastStatus = synthetic.Status
+			// Mirror the synthesized transport-error envelope too, so the sink
+			// reflects every response surf formats to stdout — not just parsed
+			// HTTP responses. (A consumer reads the error body and extracts
+			// nothing from it, which is the correct outcome.)
+			mirrorResponse(req, synthetic)
 			if fmtErr := Formatter.Format(synthetic); fmtErr != nil {
 				panic(fmtErr)
 			}
@@ -581,6 +586,12 @@ func MakeRequestAndFormat(req *http.Request) {
 		}
 		panic(err)
 	}
+
+	// Mirror the parsed response out-of-band for machine consumers
+	// ($SURF_RESPONSE_SINK_DIR) before formatting to stdout, so the full
+	// structured body is captured regardless of the selected output format or
+	// any downstream reshaping of stdout. No-op unless the env var is set.
+	mirrorResponse(req, parsed)
 
 	if err := Formatter.Format(parsed); err != nil {
 		if e, ok := err.(shorthand.Error); ok {

--- a/cli/responsesink.go
+++ b/cli/responsesink.go
@@ -1,0 +1,89 @@
+package cli
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"time"
+)
+
+// responseSinkEnv names a directory where surf mirrors each command's parsed
+// response as a JSON file. Unset (the default for interactive / CI use)
+// disables the feature entirely. Intended for machine consumers — pipelines,
+// auditing, and debugging output transformations — that need the structured
+// response independent of the format selected on the command line.
+const responseSinkEnv = "SURF_RESPONSE_SINK_DIR"
+
+// responseRecord is the machine-readable mirror of the response surf emits for
+// a single command — a parsed HTTP response, or (on network / TLS / timeout
+// failure) the synthesized transport-error envelope. It captures the structured
+// body BEFORE output formatting, so a consumer gets the complete response
+// regardless of the human / JSON / gron format the caller selected and
+// regardless of any downstream reshaping of stdout (e.g. piping through jq).
+type responseRecord struct {
+	V         int    `json:"v"`
+	Operation string `json:"operation"` // the surf subcommand, e.g. "market-ranking"
+	Method    string `json:"method"`
+	Path      string `json:"path"`
+	Query     string `json:"query,omitempty"`
+	Status    int    `json:"status"`
+	Body      any    `json:"body"` // full, pagination-merged structured response body
+}
+
+// mirrorResponse writes a responseRecord to the directory named by
+// $SURF_RESPONSE_SINK_DIR, as an atomic per-invocation file. It is a no-op when
+// the env var is unset.
+//
+// Best-effort by contract: every failure is swallowed (logged at debug) so the
+// mirror can never change the command's stdout, exit code, or timing. The file
+// is published via temp-write + rename so a concurrent reader never observes a
+// partial write; the nanosecond+pid filename keeps multiple surf calls in one
+// shell command from colliding and preserves their order for the reader.
+func mirrorResponse(req *http.Request, resp Response) {
+	dir := os.Getenv(responseSinkEnv)
+	if dir == "" {
+		return
+	}
+	// A panic here (e.g. an un-marshalable body) must never escape into the
+	// command path.
+	defer func() { _ = recover() }()
+
+	data, err := json.Marshal(responseRecord{
+		V:         1,
+		Operation: currentCommand,
+		Method:    req.Method,
+		Path:      req.URL.Path,
+		Query:     req.URL.RawQuery,
+		Status:    resp.Status,
+		Body:      resp.Body,
+	})
+	if err != nil {
+		LogDebug("response sink: marshal failed: %v", err)
+		return
+	}
+
+	base := strconv.FormatInt(time.Now().UnixNano(), 10) + "-" + strconv.Itoa(os.Getpid())
+	tmp, err := os.CreateTemp(dir, base+"-*.tmp")
+	if err != nil {
+		LogDebug("response sink: create temp failed: %v", err)
+		return
+	}
+	tmpName := tmp.Name()
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
+		LogDebug("response sink: write failed: %v", err)
+		return
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpName)
+		LogDebug("response sink: close failed: %v", err)
+		return
+	}
+	if err := os.Rename(tmpName, filepath.Join(dir, base+".json")); err != nil {
+		_ = os.Remove(tmpName)
+		LogDebug("response sink: rename failed: %v", err)
+	}
+}

--- a/cli/responsesink_test.go
+++ b/cli/responsesink_test.go
@@ -1,0 +1,153 @@
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/h2non/gock.v1"
+)
+
+func TestMirrorResponseWritesRecord(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv(responseSinkEnv, dir)
+
+	// currentCommand is a package global set by the operation runner before the
+	// request; emulate that and restore it after.
+	prev := currentCommand
+	currentCommand = "market-ranking"
+	t.Cleanup(func() { currentCommand = prev })
+
+	req := httptest.NewRequest("GET", "/gateway/market/ranking?limit=2&sort=mcap", nil)
+	resp := Response{
+		Status: 200,
+		Body: map[string]any{
+			"data": []any{
+				map[string]any{"id": "abc", "symbol": "BTC"},
+			},
+		},
+	}
+
+	mirrorResponse(req, resp)
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	require.Len(t, entries, 1, "exactly one mirror file should be written")
+	// Published atomically: the final name is .json, no leftover .tmp.
+	assert.Equal(t, ".json", filepath.Ext(entries[0].Name()))
+
+	raw, err := os.ReadFile(filepath.Join(dir, entries[0].Name()))
+	require.NoError(t, err)
+
+	var rec responseRecord
+	require.NoError(t, json.Unmarshal(raw, &rec))
+	assert.Equal(t, 1, rec.V)
+	assert.Equal(t, "market-ranking", rec.Operation)
+	assert.Equal(t, "GET", rec.Method)
+	assert.Equal(t, "/gateway/market/ranking", rec.Path)
+	assert.Equal(t, "limit=2&sort=mcap", rec.Query)
+	assert.Equal(t, 200, rec.Status)
+
+	// The mirror must carry the full structured envelope (so a consumer can read
+	// `data[].id` etc.), NOT formatted text.
+	body, ok := rec.Body.(map[string]any)
+	require.True(t, ok)
+	data, ok := body["data"].([]any)
+	require.True(t, ok)
+	require.Len(t, data, 1)
+	row, ok := data[0].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "abc", row["id"])
+	assert.Equal(t, "BTC", row["symbol"])
+}
+
+func TestMirrorResponseNoopWhenUnset(t *testing.T) {
+	t.Setenv(responseSinkEnv, "") // empty == disabled
+	req := httptest.NewRequest("GET", "/x", nil)
+	// Must neither panic nor touch the filesystem when the feature is off.
+	assert.NotPanics(t, func() {
+		mirrorResponse(req, Response{Status: 200, Body: map[string]any{"a": 1}})
+	})
+}
+
+// readSingleMirror asserts exactly one mirror file was published and returns it.
+func readSingleMirror(t *testing.T, dir string) responseRecord {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	require.Len(t, entries, 1, "exactly one mirror file expected")
+	require.Equal(t, ".json", filepath.Ext(entries[0].Name()))
+	raw, err := os.ReadFile(filepath.Join(dir, entries[0].Name()))
+	require.NoError(t, err)
+	var rec responseRecord
+	require.NoError(t, json.Unmarshal(raw, &rec))
+	return rec
+}
+
+// End-to-end: a parsed HTTP response flowing through MakeRequestAndFormat is
+// mirrored (catches placement regressions in the success branch).
+func TestMakeRequestAndFormatMirrorsParsedResponse(t *testing.T) {
+	defer gock.Off()
+	reset(false)
+	dir := t.TempDir()
+	t.Setenv(responseSinkEnv, dir)
+	prev := currentCommand
+	currentCommand = "market-ranking"
+	t.Cleanup(func() { currentCommand = prev })
+
+	gock.New("http://example.com").Get("/foo").Reply(200).JSON(map[string]any{
+		"data": []any{map[string]any{"id": "abc", "symbol": "BTC"}},
+	})
+
+	req, err := http.NewRequest("GET", "http://example.com/foo", nil)
+	require.NoError(t, err)
+	MakeRequestAndFormat(req)
+
+	rec := readSingleMirror(t, dir)
+	assert.Equal(t, "market-ranking", rec.Operation)
+	assert.Equal(t, 200, rec.Status)
+	body, ok := rec.Body.(map[string]any)
+	require.True(t, ok)
+	data, ok := body["data"].([]any)
+	require.True(t, ok)
+	require.Len(t, data, 1)
+	row, ok := data[0].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "BTC", row["symbol"])
+}
+
+// End-to-end: a transport failure synthesizes an error envelope on stdout — it
+// must be mirrored too, so the sink reflects every response surf formats (this
+// is the branch that used to `return` before mirroring).
+func TestMakeRequestAndFormatMirrorsTransportError(t *testing.T) {
+	defer gock.Off()
+	reset(false)
+	dir := t.TempDir()
+	t.Setenv(responseSinkEnv, dir)
+	prev := currentCommand
+	currentCommand = "market-ranking"
+	t.Cleanup(func() { currentCommand = prev })
+
+	gock.New("http://example.com").
+		Get("/foo").
+		ReplyError(&net.OpError{Op: "dial", Err: errors.New("connection refused")})
+
+	req, err := http.NewRequest("GET", "http://example.com/foo", nil)
+	require.NoError(t, err)
+	MakeRequestAndFormat(req)
+
+	rec := readSingleMirror(t, dir)
+	assert.Equal(t, 599, rec.Status)
+	body, ok := rec.Body.(map[string]any)
+	require.True(t, ok)
+	errObj, ok := body["error"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, ErrCodeNetworkError, errObj["code"])
+}


### PR DESCRIPTION
## What

Adds an opt-in **response sink**: set `SURF_RESPONSE_SINK_DIR` and surf mirrors each command's parsed response body (pre-formatting) as an atomic JSON file in that directory. Unset → no-op (the default for interactive / CI use).

Each record:

```json
{"v":1,"operation":"market-ranking","method":"GET","path":"/...","query":"limit=100","status":200,"body":{ ...full structured response... }}
```

## Why

The structured response only exists inside surf. Once it hits stdout it is shaped by the caller's `-o`/`-f` choice and any downstream post-processing (`| jq`, `> file`, …). A sink gives machine consumers / auditing / debugging the complete structured body independent of how stdout is rendered or consumed.

## Notes

- Captures **both** the success path and the synthesized transport-error envelope, so the sink reflects every response surf formats.
- **Best-effort + atomic** (temp + rename): never changes stdout, exit code, or timing; any failure is swallowed (logged at debug).
- Gated entirely on the env var — **zero behavior change when unset**.
- Public-CLI-neutral: no consumer-specific semantics baked in.

## Tests

- `mirrorResponse` unit tests (record shape; no-op when unset).
- End-to-end `MakeRequestAndFormat` tests (gock): a parsed 200 response and the transport-error branch are both mirrored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
