### PR TITLE
fix(cli): surface API cache write failures instead of silently re-syncing

### DIFF
--- a/cli/api.go
+++ b/cli/api.go
@@ -93,7 +93,12 @@ func cacheAPI(name string, api *API) {
 	}
 
 	Cache.Set(name+".expires", time.Now().Add(24*time.Hour))
-	Cache.WriteConfig()
+	if err := Cache.WriteConfig(); err != nil {
+		// Without the persisted expiry, LoadCachedAPI treats the cache as
+		// missing and every subsequent invocation re-syncs the spec.
+		// Surface the reason on stderr instead of silently degrading.
+		LogError("Could not persist API cache expiry (next runs will re-sync): %s", err)
+	}
 
 	b, err := cbor.Marshal(api)
 	if err != nil {
@@ -101,7 +106,7 @@ func cacheAPI(name string, api *API) {
 	}
 	filename := filepath.Join(getCacheDir(), name+".cbor")
 	if err := os.WriteFile(filename, b, 0o600); err != nil {
-		LogError("Could not write API cache %s", err)
+		LogError("Could not write API cache %s (next runs will re-sync): %s", filename, err)
 	}
 }
 


### PR DESCRIPTION
## Why

In diver instant-eval pods ~92% of questions hit `No cached API spec, syncing...` on every surf call. One contributing factor: `cacheAPI()` swallows `Cache.WriteConfig()` errors, so when the expiry write fails the CLI silently degrades into re-syncing the spec on every invocation with no clue why.

## What

- Log `Cache.WriteConfig()` failure to stderr with the reason (and a hint that next runs will re-sync)
- Include the target file path in the cbor cache write error

No behavior change on the happy path; stdout JSON untouched.

## Testing

`go build` / `go vet` clean; `go test ./cli` passes (`TestRequestRetryAfter` skipped — hangs under local proxy, pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)