### PR TITLE
[test] cover Q188 onchain tx decimal fields

### DIFF
--- a/cli/response_transform_test.go
+++ b/cli/response_transform_test.go
@@ -37,6 +37,28 @@ func TestTransformResponseForCommandAddsOnchainTxDecimalFields(t *testing.T) {
 	assert.Equal(t, "1", tx["valueNativeDecimal"])
 }
 
+func TestTransformResponseForCommandAddsQ188BlockDecimal(t *testing.T) {
+	reset(false)
+
+	body := map[string]any{
+		"data": []any{
+			map[string]any{
+				"blockNumber": "0x1630d13",
+				"value":       "0x0",
+			},
+		},
+	}
+
+	transformed, err := transformResponseForCommand("onchain-tx", body)
+	require.NoError(t, err)
+	got := transformed.(map[string]any)
+	tx := got["data"].([]any)[0].(map[string]any)
+
+	assert.Equal(t, "23268627", tx["blockNumberDecimal"])
+	assert.Equal(t, "0", tx["valueDecimal"])
+	assert.Equal(t, "0", tx["valueNativeDecimal"])
+}
+
 func TestTransformResponseForCommandHandlesFractionalNativeValue(t *testing.T) {
 	reset(false)
 


### PR DESCRIPTION
## Summary
- Add a Q188-specific regression test for onchain-tx hex quantity conversion.
- Covers `0x1630d13` -> `23268627` and `0x0` -> zero native value.

## Scope
This is **regression coverage only**. The runtime implementation that adds decimal companion fields already landed in `v1.0.9` via the agent response views change.

For diver/runtime validation, the important dependency is that the rania image uses surf CLI `1.0.9+`. Rania already merged that pin in cyberconnecthq/rania#434, and tag `0.0.78` contains it.

## Validation
- `go test ./cli -run 'TestTransformResponseForCommandAdds(Q188BlockDecimal|OnchainTxDecimalFields)'`
- Note: `go test ./...` and full `go test ./cli` were interrupted after hanging without output; focused transform tests pass.
