### PR TITLE
fix: close HTTP response body explicitly instead of defer inside loop (resource leak)

### DIFF
--- a/cli/api.go
+++ b/cli/api.go
@@ -307,10 +307,11 @@ func Load(entrypoint string, root *cobra.Command) (API, error) {
 			return API{}, err
 		}
 		if err := DecodeResponse(resp); err != nil {
+			resp.Body.Close()
 			return API{}, err
 		}
-		defer resp.Body.Close()
 		body, err := io.ReadAll(resp.Body)
+		resp.Body.Close()
 		if err != nil {
 			return API{}, err
 		}


### PR DESCRIPTION
## Problem

In `cli/api.go`, inside the `for _, checkURI := range uris` loop, each iteration uses:

```go
defer resp.Body.Close()  // runs when Load() returns, NOT at end of loop iteration
body, err := io.ReadAll(resp.Body)
```

`defer` in Go runs when the **enclosing function returns**, not when the loop iteration ends. With N URI candidates (service-desc, describedby, loader hints, entrypoint), N response bodies stay open simultaneously until `Load()` exits, holding N HTTP connections from the transport pool. Under connection limits or slow networks this causes pool exhaustion and hard-to-reproduce hangs.

The `DecodeResponse` error branch also leaks — body is never closed on early return.

## Fix

- Remove `defer resp.Body.Close()`
- Call `resp.Body.Close()` immediately after `io.ReadAll` (bytes fully consumed, safe to close)
- Also close in the `DecodeResponse` error branch to prevent leaking on early return

## References

- https://pkg.go.dev/net/http#Response — caller is always responsible for closing Body
- Effective Go: defer triggers at function return, not block exit